### PR TITLE
实现添加模型时获取支持模型列表功能

### DIFF
--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -34,6 +34,8 @@
     "saveSettings": "Click to enable",
     "settingsSaved": "Settings Saved",
     "commonModels": "Common Models:",
+    "modelList": "Model List",
+    "selectModel": "Select a model...",
     "configurations": "API Configurations",
     "newConfig": "New Config",
     "configName": "Configuration Name",
@@ -43,7 +45,10 @@
     "cannotDeleteLastConfig": "Cannot delete the last configuration",
     "confirmDelete": "Are you sure you want to delete this configuration?",
     "createFirstConfig": "Create Your First Configuration",
-    "noConfigs": "No API configurations yet"
+    "noConfigs": "No API configurations yet",
+    "getModelList": "Get Model List",
+    "getModelListSuccess": "Get Model List Success",
+    "getModelListError": "Get Model List Error"
   },
   "llmSettings": {
     "title": "Settings",

--- a/app/i18n/locales/zh.json
+++ b/app/i18n/locales/zh.json
@@ -34,6 +34,8 @@
     "saveSettings": "点击启用",
     "settingsSaved": "设置已保存",
     "commonModels": "常用模型推荐:",
+    "modelList": "模型列表",
+    "selectModel": "选择模型",
     "configurations": "API 配置",
     "newConfig": "新建配置",
     "configName": "配置名称",
@@ -44,7 +46,10 @@
     "confirmDelete": "确定要删除此配置吗？",
     "configCreated": "配置已创建",
     "noConfigs": "暂无API配置",
-    "createFirstConfig": "创建你的第一个配置"
+    "createFirstConfig": "创建你的第一个配置",
+    "getModelList": "获取模型列表",
+    "getModelListSuccess": "获取模型列表成功",
+    "getModelListError": "获取模型列表失败"
   },
   "llmSettings": {
     "title": "设置",


### PR DESCRIPTION
在创建模型配置时，增加按钮功能支持，获取支持的模型列表。

示例：
<img width="253" alt="Snipaste_2025-06-02_20-06-56" src="https://github.com/user-attachments/assets/5f78da52-b571-4d31-b216-63b3d19590bc" />

<img width="254" alt="Snipaste_2025-06-02_20-07-22" src="https://github.com/user-attachments/assets/ac5b63c0-b0c1-4fc4-aa06-f9ab7d787d83" />

<img width="293" alt="Snipaste_2025-06-02_20-17-31" src="https://github.com/user-attachments/assets/05bf9627-eb9e-4a6c-98af-2004358cdfed" />

修复 issues #3 

