### PR TITLE
fix: improve autofill styles for input elements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,6 +75,30 @@ select:focus {
   box-shadow: 0 0 0 2px rgba(93, 93, 93, 0.2);
 }
 
+/* Fix autofill styles for consistent appearance */
+input:-webkit-autofill,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 1000px transparent inset !important;
+  box-shadow: 0 0 0 1000px transparent inset !important;
+  -webkit-text-fill-color: #eae6db !important;
+  caret-color: #f9c86d !important;
+  transition: background-color 9999s ease-in-out 0s;
+  background-color: transparent !important;
+  background-image: none !important;
+}
+
+/* Additional autofill fixes for different input types */
+input[type="email"]:-webkit-autofill,
+input[type="password"]:-webkit-autofill,
+input[type="text"]:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 1000px transparent inset !important;
+  box-shadow: 0 0 0 1000px transparent inset !important;
+  -webkit-text-fill-color: #eae6db !important;
+  background-color: transparent !important;
+}
+
 .story-text {
   color: var(--story-text-color);
   font-size: 0.95rem;


### PR DESCRIPTION
### **User description**
- Added styles to enhance the appearance of autofilled input fields, ensuring a consistent look across different input types.
- Implemented specific styles for email, password, and text input types to address autofill behavior and improve user experience.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed autofill styling inconsistencies across input elements

- Added webkit-specific styles to maintain transparent backgrounds

- Implemented consistent text color and caret styling

- Enhanced user experience for email, password, and text inputs


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Input Elements"] --> B["Autofill Detection"]
  B --> C["Webkit Styles Applied"]
  C --> D["Transparent Background"]
  C --> E["Consistent Text Color"]
  C --> F["Custom Caret Color"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Enhanced autofill styling for input consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/globals.css

<li>Added webkit-autofill styles for consistent appearance<br> <li> Implemented transparent background with box-shadow override<br> <li> Set custom text fill color and caret color<br> <li> Added specific styles for email, password, and text input types


</details>


  </td>
  <td><a href="https://github.com/Narratium/Narratium.ai/pull/64/files#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>